### PR TITLE
Run tasks import in the 'import' environment

### DIFF
--- a/.github/workflows/import.yml
+++ b/.github/workflows/import.yml
@@ -17,6 +17,12 @@ on:
 jobs:
   import:
     runs-on: ubuntu-latest
+
+    # The 'import' environment requires review before allowing jobs to proceed.
+    # This is here as a molly-guard rather than a security measure, purely on
+    # the basis that this operation is disruptive.
+    environment: import
+
     steps:
     - uses: actions/checkout@v4
       with:


### PR DESCRIPTION
This adds a review step on the rather disruptive/noisy operation of doing the import.